### PR TITLE
Fill cds

### DIFF
--- a/asciitable.py
+++ b/asciitable.py
@@ -668,7 +668,7 @@ class NumpyOutputter(BaseOutputter):
             maarr = recarr.view(numpy.ma.MaskedArray)
             for col in cols:
                 if col.fill_values:
-                    maarr[col.name][numpy.array(col.mask)] = numpy.ma.masked
+                    maarr[col.name] = numpy.ma.masked_where(col.mask, maarr[col.name])
             return maarr
         else:
             return recarr
@@ -1432,7 +1432,7 @@ class CdsHeader(BaseHeader):
                 if col.descr.startswith('?') and col.format[0] in ('F', 'E'):
                     self.data.fill_values.append(('', 'nan', match.group('name')))
                 if col.descr.startswith('?=') and col.format[0] in ('F', 'E'):
-                    self.data.fill_values.append(([col.descr.split()[0][2:]], 'nan', match.group('name')))
+                    self.data.fill_values.append((col.descr.split()[0][2:], 'nan', match.group('name')))
                 cols.append(col)
             else:  # could be a continuation of the previous col's description
                 if cols:

--- a/test/test_cds_header_from_readme.py
+++ b/test/test_cds_header_from_readme.py
@@ -1,5 +1,6 @@
 # run from main directory; not from test/
 import asciitable
+import math
 readme = "t/vizier/ReadMe"
 
 def test_header_from_readme():
@@ -5296,7 +5297,10 @@ def test_header_from_readme():
           0.670, 
           0.313] 
     for i, val in enumerate(table.field('Q')):
-        assert val == Q[i]
+        if math.isnan(val):
+            assert Q[i] == -9.999 #the text value for a missing value in that table
+        else:
+            assert val == Q[i]
 
 if __name__ == "__main__": # run from main directory; not from test/
     test_header_from_readme()

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -273,6 +273,18 @@ def test_fill_values_list(numpy):
     else:
         assert_equal(data['a'],[42,42])
 
+@has_numpy_and_not_has_numpy
+def test_masking_Cds(numpy):
+    f = 't/cds.dat'
+    testfile = get_testfiles(f)
+    data = asciitable.read(f, numpy=numpy, 
+                           **testfile['opts'])
+    if numpy:
+        assert_true(data['AK'].mask[0])
+        assert_true(not data['Fit'].mask[0])
+    else:
+        assert_true(math.isnan(tab['AK'][0]))
+        assert_true(not math.isnan(tab['Fit'][0]))
 
 def get_testfiles(name=None):
     """Set up information about the columns, number of rows, and reader params to

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1,5 +1,6 @@
 import re
 import glob
+import math
 from nose.tools import *
 
 import asciitable
@@ -283,8 +284,8 @@ def test_masking_Cds(numpy):
         assert_true(data['AK'].mask[0])
         assert_true(not data['Fit'].mask[0])
     else:
-        assert_true(math.isnan(tab['AK'][0]))
-        assert_true(not math.isnan(tab['Fit'][0]))
+        assert_true(math.isnan(data['AK'][0]))
+        assert_true(not math.isnan(data['Fit'][0]))
 
 def get_testfiles(name=None):
     """Set up information about the columns, number of rows, and reader params to


### PR DESCRIPTION
Cds tables can contain missing values, realized as empty stings or with special values. These special values are then given in the first few characters of the column description in the form `?=value`.
For columns with float values (type E and F) I have implemented an automated setting for fill_values, that masks these spacial values in a masked array. Nothing has changed for ascii or integer columns as these do not have a natural value which can be used to replace the masked or missing values in a transparent way.
