### PR TITLE
Adds handler for tables with inconsistent header/data row

### DIFF
--- a/asciitable/core.py
+++ b/asciitable/core.py
@@ -763,6 +763,10 @@ class BaseReader(object):
     ``header``, ``data``, ``inputter``, and ``outputter`` attributes.  Each
     of these is an object of the corresponding class.
 
+    There is one method ``inconsistent_hander`` that can be used to customize the
+    behavior of ``read()`` in the event that a data row doesn't match the header.
+    The default behavior is to raise an InconsistentTableError.
+
     """
     def __init__(self):
         self.header = BaseHeader()


### PR DESCRIPTION
This pull request adds a method to the BaseReader that allows for customization of the behavior of read() when a row's number of entries does not match the header.  The main purpose I have in mind is to allow skipping of bad rows (just override the new inconsistent_handler method to always return None), although other ways of massaging bad columns are possible.

Presumably this could also be put in the splitter somehow, but it's not clear to me that the splitters have any knowledge of the correct number of columns, which is fairly important if you want to massage the entries for a badly-formatted table.
