### PR TITLE
Use DAOPHOT fixed width information

### DIFF
--- a/asciitable/core.py
+++ b/asciitable/core.py
@@ -944,19 +944,23 @@ class ContinuationLinesInputter(BaseInputter):
       2 3
       4 5 \
       6
+    
+    When joining ``continuation_char`` is replaced by ``replace_char``.
     """
 
     continuation_char = '\\'
+    replace_char = ' '
 
     def process_lines(self, lines):
-        striplines = (x.strip() for x in lines)
-        lines = [x for x in striplines if len(x) > 0]
+        #striplines = (x.strip() for x in lines)
+        #lines = [x for x in striplines if len(x) > 0]
 
         parts = []
         outlines = []
         for line in lines:
             if line.endswith(self.continuation_char):
-                parts.append(line.rstrip(self.continuation_char))
+                #parts.append(line.rstrip(self.continuation_char))
+                parts.append(line.replace(self.continuation_char, self.replace_char))
             else:
                 parts.append(line)
                 outlines.append(''.join(parts))

--- a/t/daophot.dat
+++ b/t/daophot.dat
@@ -33,13 +33,13 @@
 #
 #N ID    XCENTER   YCENTER   MAG         MERR          MSKY           NITER    \
 #U ##    pixels    pixels    magnitudes  magnitudes    counts         ##       \
-#F %-9d  %-10.3f   %-10.3f   %-12.3f     %-14.3f       %-15.7g        %-6d     
+#F %-9d  %-10.3f   %-10.3f   %-12.3f     %-14.3f       %-15.7g        %-6d      
 #
 #N         SHARPNESS   CHI         PIER  PERROR                                \
 #U         ##          ##          ##    perrors                               \
-#F         %-23.3f     %-12.3f     %-6d  %-13s                                 
+#F         %-23.3f     %-12.3f     %-6d  %-13s                                  
 #
 14       138.538   256.405   15.461      0.003         34.85955       4        \
-         -0.032      0.802       0     No_error                              
+         -0.032      0.802       0     No_error                                 
 18       18.114    280.170   22.329      0.206         30.12784       4        \
-         -2.544      1.104       0     No_error      
+         -2.544      1.104       0     No_error                                 


### PR DESCRIPTION
Really, DAOPhot uses fixed width tables. So far, `asciitable` just used the normal splitter, but that sometimes fails, if values in columns are so long that there is not white space in between. This patch makes full use of the width info in the DAOPhot headers and the FixedWidthSplitter.
Please check with nose, though (I don't have that installed on this machine).
